### PR TITLE
Add append_to_end

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
 Cargo.lock
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ env_perm::check_or_set("DUMMY", 1).expect("Failed to find or set DUMMY");
 // Append $HOME/some/cool/bin to $PATH
 // export PATH= "$HOME/some/cool/bin:$PATH"
 env_perm::append("PATH", "$HOME/some/cool/bin").expect("Couldn't find PATH");
+// Append $HOME/some/cooler/bin to the end of the path
+// export PATH="$PATH:$HOME/some/cooler/bin"
+env_perm::append_to_end("PATH", "$HOME/some/cooler/bin").expect("Couldn't find PATH");
 // Sets a variable without checking if it exists.
 // Note you need to use a raw string literal to include ""
 // export DUMMY="/something"

--- a/examples/set_dummy.rs
+++ b/examples/set_dummy.rs
@@ -7,6 +7,9 @@ fn main() {
     // Append $HOME/some/cool/bin to $PATH
     // export PATH= "$HOME/some/cool/bin:$PATH"
     env_perm::append("PATH", "$HOME/some/cool/bin").expect("Couldn't find PATH");
+    // Append $HOME/some/cooler/bin to the end of the path
+    // export PATH= "$PATH:$HOME/some/cooler/bin"
+    env_perm::append_to_end("PATH", "$HOME/some/cooler/bin").expect("Couldn't find PATH");
     // Sets a variable without checking if it exists.
     // Note you need to use a raw string literal to include ""
     // export DUMMY="/something"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,9 @@
 //! // Append $HOME/some/cool/bin to $PATH
 //! // export PATH= "$HOME/some/cool/bin:$PATH"
 //! env_perm::append("PATH", "$HOME/some/cool/bin").expect("Couldn't find PATH");
+//! // Append $HOME/some/cooler/bin to the front of the path
+//! // export PATH="$PATH:$HOME/some/cooler/bin"
+//! env_perm::append_to_end("PATH", "$HOME/some/cooler/bin").expect("Couldn't find PATH");
 //! // Sets a variable without checking if it exists.
 //! // Note you need to use a raw string literal to include ""
 //! // export DUMMY="/something"
@@ -39,6 +42,13 @@ where T: fmt::Display + AsRef<std::ffi::OsStr>,
 pub fn append<T: fmt::Display>(var: T, value: T) -> io::Result<()> {
     let mut profile = get_profile()?;
     writeln!(profile, "\nexport {}=\"{}:${}\"", var, value, var)?;
+    profile.flush()
+}
+
+/// Appends a value to an environment variable at either the front or end
+pub fn append_to_end<T: fmt::Display>(var: T, value: T) -> io::Result<()> {
+    let mut profile = get_profile()?;
+    writeln!(profile, "\nexport {}=\"${}:{}\"", var, var, value)?;
     profile.flush()
 }
 


### PR DESCRIPTION
This adds append_to_end to the library to allow appending to the end of the variable rather than the front:

export PATH= "$PATH:$HOME/some/cooler/bin"

This is useful for adding to the PATH as some users may not want the new item to be the first in the path search.